### PR TITLE
D10-93 / D10-94: Cannot be compatible with D9 and D10, due to normalizer type hints.

### DIFF
--- a/islandora_iiif_presentation_api.info.yml
+++ b/islandora_iiif_presentation_api.info.yml
@@ -2,7 +2,7 @@ name: Islandora IIIF Presentation API
 type: module
 description: 'Provides a IIIF Presentation API implementation for Islandora entities within Drupal.'
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9
 dependencies:
   - drupal:image
   - drupal:media


### PR DESCRIPTION
Really, should would be nice to be able to counter-recommend the use of `1.0.0` in some way? Dunno.