### PR TITLE
SUPM-1656: Add missing typehints.

### DIFF
--- a/modules/islandora_iiif_presentation_api_bulk_loading/src/Normalizer/V3/MemberOfEntityReferenceFieldItemListNormalizer.php
+++ b/modules/islandora_iiif_presentation_api_bulk_loading/src/Normalizer/V3/MemberOfEntityReferenceFieldItemListNormalizer.php
@@ -48,7 +48,7 @@ class MemberOfEntityReferenceFieldItemListNormalizer extends UpstreamNormalizer 
   /**
    * {@inheritDoc}
    */
-  public function normalize($object, $format = NULL, array $context = []) {
+  public function normalize($object, $format = NULL, array $context = []) : float|int|bool|\ArrayObject|array|string|null {
     if ($this->useInner) {
       return $this->inner->normalize($object, $format, $context);
     }

--- a/modules/islandora_iiif_presentation_api_bulk_loading/src/Normalizer/V3/ModelEntityReferenceItemNormalizer.php
+++ b/modules/islandora_iiif_presentation_api_bulk_loading/src/Normalizer/V3/ModelEntityReferenceItemNormalizer.php
@@ -32,7 +32,7 @@ class ModelEntityReferenceItemNormalizer extends UpstreamNormalizer {
   /**
    * {@inheritDoc}
    */
-  public function normalize($object, $format = NULL, array $context = []) {
+  public function normalize($object, $format = NULL, array $context = []) : float|int|bool|\ArrayObject|array|string|null {
     if ($this->useInner) {
       return $this->inner->normalize($object, $format, $context);
     }


### PR DESCRIPTION
Was blowing up with: 

```
PHP Fatal error:  Declaration of Drupal\islandora_iiif_presentation_api_bulk_loading\Normalizer\V3\MemberOfEntityReferenceFieldItemListNormalizer::normalize($object, $format = null, array $context = []) must be compatible with Drupal\islandora_iiif_presentation_api\Normalizer\V3\MemberOfEntityReferenceFieldItemListNormalizer::normalize($object, $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null in /var/www/html/web/modules/contrib/islandora_iiif_presentation_api/modules/islandora_iiif_presentation_api_bulk_loading/src/Normalizer/V3/MemberOfEntityReferenceFieldItemListNormalizer.php on line 51
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code quality and type safety in normalizer components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->